### PR TITLE
Handle Tvheadend connection problems

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -44,6 +44,10 @@
         </thead>
         <tbody>
           <tr>
+            <td>Status</td>
+            <td id="status"></td>
+          </tr>
+          <tr>
             <td>URL for Tvheadend</td>
             <td><a id="tvheadendUrl"></a></td>
           </tr>

--- a/src/public/js/index.js
+++ b/src/public/js/index.js
@@ -27,5 +27,6 @@ fetch('/antennas_config.json').then((result) => {
   urlReplace('#antennasUrl')(config.antennas_url);
   replace('#tvheadendWeight')(config.tvheadend_weight);
   replace('#tunerCount')(config.tuner_count);
+  replace('#status')(config.status);
 });
 


### PR DESCRIPTION
This adds error handling in the `/lineup.json` endpoint for when Tvheadend is not responding, or responding in unexpected ways.

This also adds a new status field on the Antennas page that can show `All systems go` when everything is good, `Failed to authenticate with Tvheadend` when the error is an authentication error (wrong password for Tvheadend for example), `Unable to find Tvheadend server, make sure the server is up and the configuration are pointing to the right spot` when the server is started with an invalid Tvheadend config, and failing that, `Unknown`