### PR TITLE
Fix device appearing offline

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,3 +1,4 @@
 tvheadend_url: http://admin:test@192.168.0.1:9981
 antennas_url: http://127.0.0.1:5004
 tuner_count: 6 # numbers of tuners in tvheadend
+device_uuid: 2f70c0d7-90a3-4429-8275-cbeeee9cd605

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ module.exports = function() {
   tvheadendUrl = process.env.TVHEADEND_URL || config.tvheadend_url;
   antennasUrl = process.env.ANTENNAS_URL || config.antennas_url;
   tunerCount = process.env.TUNER_COUNT || config.tuner_count;
+  DeviceUuid = process.env.DEVICE_UUID || config.device_uuid;
   let parsedTvheadendURI = parseTvheadendURI(tvheadendUrl);
   return {
     tvheadend_parsed_uri: parsedTvheadendURI.uri,
@@ -34,5 +35,6 @@ module.exports = function() {
     tvheadend_url: tvheadendUrl,
     antennas_url: antennasUrl,
     tuner_count: tunerCount,
+    device_uuid: DeviceUuid
   }
 }

--- a/src/device.js
+++ b/src/device.js
@@ -2,14 +2,14 @@ const config = require('./config');
 
 module.exports = function() {
   return {
-    FriendlyName: "Antennas",
+    FriendlyName: "HDHomerun (Antennas)",
     Manufacturer: "Silicondust",
     ManufacturerURL: "https://github.com/thejf/antennas",
     ModelNumber: "HDTC-2US",
     FirmwareName: "hdhomeruntc_atsc",
     TunerCount: config().tuner_count,
     FirmwareVersion: "20170930",
-    DeviceID: "12345670",
+    DeviceID: config().device_uuid,
     DeviceAuth: "test1234",
     BaseURL: config().antennas_url,
     LineupURL: `${config().antennas_url}/lineup.json`

--- a/src/router.js
+++ b/src/router.js
@@ -44,6 +44,7 @@ module.exports = function() {
       <major>1</major>
       <minor>0</minor>
   </specVersion>
+  <URLBase>${device().BaseURL}</URLBase>
   <device>
     <dlna:X_DLNADOC>DMS-1.50</dlna:X_DLNADOC>
     <pnpx:X_hardwareId>VEN_0115&amp;DEV_1040&amp;SUBSYS_0001&amp;REV_0004 VEN_0115&amp;DEV_1040&amp;SUBSYS_0001 VEN_0115&amp;DEV_1040</pnpx:X_hardwareId>
@@ -66,15 +67,15 @@ module.exports = function() {
       <serviceType>urn:schemas-upnp-org:service:ConnectionManager:1</serviceType>
       <serviceId>urn:upnp-org:serviceId:ConnectionManager</serviceId>
       <SCPDURL>/ConnectionManager.xml</SCPDURL>
-      <controlURL>${device().BaseURL}/ConnectionManager</controlURL>
-      <eventSubURL>${device().BaseURL}/ConnectionManager</eventSubURL>
+      <controlURL>${device().BaseURL}/ConnectionManager.xml</controlURL>
+      <eventSubURL>${device().BaseURL}/ConnectionManager.xml</eventSubURL>
     </service>
     <service>
       <serviceType>urn:schemas-upnp-org:service:ContentDirectory:1</serviceType>
       <serviceId>urn:upnp-org:serviceId:ContentDirectory</serviceId>
       <SCPDURL>/ContentDirectory.xml</SCPDURL>
-      <controlURL>${device().BaseURL}/ContentDirectory</controlURL>
-      <eventSubURL>${device().BaseURL}/ContentDirectory</eventSubURL>
+      <controlURL>${device().BaseURL}/ContentDirectory.xml</controlURL>
+      <eventSubURL>${device().BaseURL}/ContentDirectory.xml</eventSubURL>
     </service>
   </serviceList>
   <iconList>

--- a/src/ssdp.js
+++ b/src/ssdp.js
@@ -1,9 +1,12 @@
+const device = require('./device');
+
 const SSDP = require('node-ssdp').Server
 , server = new SSDP({
   location: {
     port: 5004,
     path: '/device.xml'
   },
+  udn: `uuid:${device().DeviceID}`,
   allowWildcards: true,
   ssdpSig: 'Antennas/3.0 UPnP/1.0'
 })


### PR DESCRIPTION
These changes seem to keep the device marked as online once it's added and in most cases allows for the device to be automatically found.

It does seem however that Plex does act strangely sometimes, but once a device has been added, it appears to remain online.

It is recommended to delete the existing device so the new UUID is marked with this device, along with the SSDP packets being marked with the correct UUID fixes most problems. Other adjustments have been inspired by https://github.com/tombowditch/telly , such as the name of the device and baseurl in the device.xml.

**Restarting Plex once a device has been added seems to be required**

ControlURL and EventSubURL adjustments have an unknown result, it appears plex never calls them anyway. I have left them in there but they could probably be reverted. It however didn't make sense to revert them as the endpoint didn't match the URL